### PR TITLE
Fix for stack trace rendering issue

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/log4j/appender/ReportPortalAppender.java
+++ b/src/main/java/com/epam/ta/reportportal/log4j/appender/ReportPortalAppender.java
@@ -26,6 +26,7 @@ import com.epam.ta.reportportal.ws.model.log.SaveLogRQ;
 import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.spi.LoggingEvent;
 import rp.com.google.common.base.Function;
+import rp.com.google.common.base.Throwables;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,10 +71,8 @@ public class ReportPortalAppender extends AppenderSkeleton {
 					 * stack-trace to logged message string
 					 */
 					StringBuilder throwable = new StringBuilder();
-					if (null != event.getThrowableInformation()) {
-						for (String oneLine : event.getThrowableStrRep()) {
-							throwable.append(oneLine);
-						}
+					if (null != event.getThrowableInformation() && null != event.getThrowableInformation().getThrowable()) {
+						throwable.append(Throwables.getStackTraceAsString(event.getThrowableInformation().getThrowable()));
 					}
 
 					// ReportPortalMessage is reported


### PR DESCRIPTION
Use Throwables utility method to get a formatted stack trace string
fixes #6 