### PR TITLE
Bump Log4J2 from `2.16.0` to `2.17.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.0'
     implementation 'log4j:log4j:1.2.17'
     implementation 'com.epam.reportportal:client-java:5.1.0'
     implementation 'com.epam.reportportal:commons-model:5.0.0'


### PR DESCRIPTION
The latest DoS vulnerability (CVE-2021-45105) is fixed in 2.17.0.