### PR TITLE
Fixed bug with wrong File object cast  in ReportPortalLog4j2Appender.java

### DIFF
--- a/src/main/java/com/epam/ta/reportportal/log4j/appender/ReportPortalLog4j2Appender.java
+++ b/src/main/java/com/epam/ta/reportportal/log4j/appender/ReportPortalLog4j2Appender.java
@@ -99,7 +99,7 @@ public class ReportPortalLog4j2Appender extends AbstractAppender {
 						byteSource = rpMessage.getData();
 						message = rpMessage.getMessage();
 					} else if (objectMessage instanceof File) {
-						final File file = (File) event.getMessage();
+						final File file = (File) objectMessage;
 						byteSource = new TypeAwareByteSource(asByteSource(file), detect(file));
 						message = "File reported";
 


### PR DESCRIPTION
Fixed bug with wrong object casting. 