### PR TITLE
Load RP Log4J2 plugin from plugin listing file on classpath

### DIFF
--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -47,7 +47,7 @@ Update `log4j2.xml` as follows
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration packages="com.epam.ta.reportportal.log4j.appender">
+<configuration>
     <properties>
         <property name="pattern">[%d{HH:mm:ss}] %-5p (%F:%L) - %m%n</property>
     </properties>
@@ -71,7 +71,6 @@ Update `log4j2.json` as follows
 ```JSON
 {
   "configuration": {
-    "packages": "com.epam.ta.reportportal.log4j.appender",
     "properties": {
       "property": {
         "name": "pattern",

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ repositories {
 
 dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.17.2'
+    annotationProcessor 'org.apache.logging.log4j:log4j-core:2.17.2'
     implementation 'com.epam.reportportal:client-java:5.1.16'
     implementation 'com.epam.reportportal:commons-model:5.0.0'
 


### PR DESCRIPTION
Loading of Log4J2 plugins using package scanning is [deprecated]( https://logging.apache.org/log4j/2.x/release-notes/2.20.0.html#deprecated).
The only available option is [serialized plugin listing files](https://logging.apache.org/log4j/2.x/manual/plugins.html) on the classpath.
More details on deprecation: https://issues.apache.org/jira/browse/LOG4J2-3644.